### PR TITLE
change metadata code block to JS so it renders nicely

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ python whatagan
 
 Metadata will be stored in JSON format with the following schema:
 
-```json
+```js
 {
     // 
     "location": "Whataburger+2424+Baldwin+Blvd,Corpus-Christi,TX",


### PR DESCRIPTION
Hey @JimothyJohn! I discovered this curious and compelling project via https://replicate.com/jimothyjohn/whataburger-detector

JSON doesn't support comments, so they look pretty wonky now. This PR changes the code block to JS so the comments look better.

Rendered: https://github.com/zeke/WhataGAN/blob/7860098792341fce98d3b9db53333cba07bf569a/README.md